### PR TITLE
✨ Added deletion of templates in Zabbix

### DIFF
--- a/zabbixci/utils/git/git.py
+++ b/zabbixci/utils/git/git.py
@@ -76,6 +76,12 @@ class Git:
         """
         return self._repository.diff(*args, **kwargs)
 
+    def status(self, *args: P.args, **kwargs: P.kwargs):
+        """
+        Get the status of the repository
+        """
+        return self._repository.status(*args, **kwargs)
+
     def switch_branch(self, branch: str):
         """
         Switch to a branch, if the branch does not exist, create it

--- a/zabbixci/utils/template/template.py
+++ b/zabbixci/utils/template/template.py
@@ -36,6 +36,10 @@ class Template:
         return self._template["name"]
 
     @property
+    def template_id(self):
+        return self._template["templateid"]
+
+    @property
     def primary_group(self):
         """
         The most specific group of the template, the lowest child in the hierarchy

--- a/zabbixci/utils/zabbix/zabbix.py
+++ b/zabbixci/utils/zabbix/zabbix.py
@@ -55,3 +55,11 @@ class Zabbix:
 
     def get_server_version(self):
         return self.zapi.send_api_request("apiinfo.version")["result"]
+
+    def get_templates_name(self, name: list[str]):
+        return self.zapi.send_api_request("template.get", {"filter": {"host": name}})[
+            "result"
+        ]
+
+    def delete_template(self, template_ids: list[int]):
+        return self.zapi.send_api_request("template.delete", template_ids)["result"]


### PR DESCRIPTION
When a template is deleted from the Git repo, changes are not propagated deleting the template from Zabbix.

This PR also made some changes to the detection of unstaged changes, used for detection of differences between git remote and Zabbix state. Instead of using a git diff, a git status command is now used to inspect unstaged changes. This should work fine because all reported changes from Zabbix should be marked as unstaged changes in the cache dir.