### PR TITLE
🐛 Fixed error on pushing to non-existing remote branch

### DIFF
--- a/zabbixci/utils/git/git.py
+++ b/zabbixci/utils/git/git.py
@@ -43,12 +43,15 @@ class Git:
         Check if the repository is ahead of the remote repository
         """
         branch = self._repository.head.shorthand
+        try:
+            remote_id = self._repository.lookup_reference(
+                f"refs/remotes/origin/{branch}"
+            ).target
 
-        remote_id = self._repository.lookup_reference(
-            f"refs/remotes/origin/{branch}"
-        ).target
-
-        return self._repository.head.target != remote_id
+            return self._repository.head.target != remote_id
+        except KeyError:
+            # Remote branch does not exist, we must push our state to the remote
+            return True
 
     @property
     def current_branch(self):


### PR DESCRIPTION
Fixes #21 

Added exception catch for missing remote branch, pushing the local state to the remote when the branch is not available on the remote.