### PR TITLE
✨ Added dry run option to test behavior of ZabbixCI import and push

### DIFF
--- a/zabbixci/cli.py
+++ b/zabbixci/cli.py
@@ -102,6 +102,12 @@ def read_args():
         "--cache",
         help="Cache path for git repository, defaults to ./cache",
     )
+    parser.add_argument(
+        "--dry-run",
+        help="Dry run, only show changes",
+        action="store_true",
+        default=None,
+    )
 
     # ZabbixCI advanced
     parser.add_argument(

--- a/zabbixci/settings.py
+++ b/zabbixci/settings.py
@@ -28,6 +28,7 @@ class Settings:
     GIT_PUBKEY = None
     GIT_PRIVKEY = None
     GIT_KEYPASSPHRASE = None
+    DRY_RUN = False
 
     @classmethod
     def from_env(cls):

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -273,7 +273,8 @@ class ZabbixCI:
             ]
 
             if len(template_ids):
-                self._zabbix.delete_template(template_ids)
+                if not self._settings.DRY_RUN:
+                    self._zabbix.delete_template(template_ids)
 
         # clean local changes
         self._git.clean()

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -140,7 +140,8 @@ class ZabbixCI:
         else:
             self.logger.info("No staged changes, updating remote with current state")
 
-        self._git.push(Settings.REMOTE, self._git_cb)
+        if not self._settings.DRY_RUN:
+            self._git.push(Settings.REMOTE, self._git_cb)
 
     def pull(self):
         """
@@ -239,7 +240,9 @@ class ZabbixCI:
             # Import the templates
             for template in templates:
                 self.logger.info(f"Importing {template.name}, level {template._level}")
-                self._zabbix.import_template(template)
+
+                if not self._settings.DRY_RUN:
+                    self._zabbix.import_template(template)
 
         template_names = []
 


### PR DESCRIPTION
The dry run option is available as config option `dry_run`, env var `DRY_RUN` and cli argument `--dry-run`

Dry run disabled all non-reversible changes ZabbixCI can make.
- Zabbix imports
- Git pushes
- Zabbix template deletions

Closes #45 