### PR TITLE
🐛 Import rules have been adjusted to import template dependencies

### DIFF
--- a/zabbixci/utils/zabbix/zabbix.py
+++ b/zabbixci/utils/zabbix/zabbix.py
@@ -50,6 +50,16 @@ class Zabbix:
                         "createMissing": True,
                         "updateExisting": True,
                     },
+                    "discoveryRules": {
+                        "createMissing": True,
+                        "updateExisting": True,
+                        "deleteMissing": True,
+                    },
+                    "graphs": {
+                        "createMissing": True,
+                        "updateExisting": True,
+                        "deleteMissing": True,
+                    },
                     "httptests": {
                         "createMissing": True,
                         "updateExisting": True,

--- a/zabbixci/utils/zabbix/zabbix.py
+++ b/zabbixci/utils/zabbix/zabbix.py
@@ -50,6 +50,26 @@ class Zabbix:
                         "createMissing": True,
                         "updateExisting": True,
                     },
+                    "httptests": {
+                        "createMissing": True,
+                        "updateExisting": True,
+                        "deleteMissing": True,
+                    },
+                    "items": {
+                        "createMissing": True,
+                        "updateExisting": True,
+                        "deleteMissing": True,
+                    },
+                    "triggers": {
+                        "createMissing": True,
+                        "updateExisting": True,
+                        "deleteMissing": True,
+                    },
+                    "valueMaps": {
+                        "createMissing": True,
+                        "updateExisting": True,
+                        "deleteMissing": True,
+                    },
                 },
                 "source": export,
             },


### PR DESCRIPTION
The following import rules have been added to account for template dependency creation, deletion and updates.

- discoveryRules
- graphs
- httptests
- items
- triggers
- valueMaps

Closes #52 