### PR TITLE
♻ Batching of exports has been disabled

### DIFF
--- a/zabbixci/utils/template/template.py
+++ b/zabbixci/utils/template/template.py
@@ -150,22 +150,10 @@ class Template:
             return Template(yaml.load(file)["zabbix_export"])
 
     @staticmethod
-    def from_zabbix(template: dict, template_groups: dict, zabbix_version: str):
+    def from_zabbix(export: dict):
         """
         Create a individual template from a bulk Zabbix export
         """
-        groups = list(
-            filter(
-                lambda group: group["name"]
-                in [group["name"] for group in template["groups"]],
-                template_groups,
-            )
-        )
+        # TODO: Prepare dict for export, otherwise remove this method and use the constructor directly
 
-        return Template(
-            {
-                "version": zabbix_version,
-                "template_groups": groups,
-                "templates": [template],
-            }
-        )
+        return Template(export)


### PR DESCRIPTION
Export batching has been disabled due to the incompatibility with creating full exports of a complete template with its complex triggers and graphs. Fixing #55 

However, this does come with a significant speed decrease, taking 3m55.641s for a push of the default 7.0 templates.