### PR TITLE
⚡ Significant speed increase adding async operations to exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ maintainers = [
     { name = "Raymond Kuiper", email = "raymond.kuiper@retigra.nl" },
 ]
 
-dependencies = ["zabbix-utils", "ruamel.yaml", "regex", "pygit2"]
+dependencies = ["zabbix-utils", "ruamel.yaml", "regex", "pygit2", "aiohttp"]
 license = { file = "LICENSE.txt" }
 
 [project.urls]

--- a/zabbixci/settings.py
+++ b/zabbixci/settings.py
@@ -20,7 +20,7 @@ class Settings:
     TEMPLATE_WHITELIST = []
     TEMPLATE_BLACKLIST = []
     CACHE_PATH = "./cache"
-    BATCH_SIZE = 50
+    BATCH_SIZE = 5
     IGNORE_TEMPLATE_VERSION = False
     INSECURE_SSL_VERIFY = False
     GIT_USERNAME = "git"


### PR DESCRIPTION
Implemented async operation for Zabbix exports. Decreasing the time it takes to export and compare Zabbix templates.

Decreasing the previous time tested in #57 from 3m55.641s to 2m18.091s