### PR TITLE
✨ Template path is changed to Template Name

### DIFF
--- a/zabbixci/utils/git/git.py
+++ b/zabbixci/utils/git/git.py
@@ -210,7 +210,7 @@ class Git:
         merge_result, merge_pref = self._repository.merge_analysis(remote_id)
 
         if merge_result & MergeAnalysis.UP_TO_DATE:
-            logger.info("Already up to date")
+            logger.debug("Already up to date")
             return
 
         if merge_result & MergeAnalysis.FASTFORWARD:

--- a/zabbixci/utils/template/template.py
+++ b/zabbixci/utils/template/template.py
@@ -38,7 +38,7 @@ class Template:
 
     @property
     def name(self):
-        return self._template["name"]
+        return self._template["template"]
 
     @property
     def uuid(self):
@@ -190,7 +190,7 @@ class Template:
         )
 
         with open(
-            f"{Settings.CACHE_PATH}/{Settings.TEMPLATE_PREFIX_PATH}/{self.truncated_groups}/{self._template['name']}.yaml",
+            f"{Settings.CACHE_PATH}/{Settings.TEMPLATE_PREFIX_PATH}/{self.truncated_groups}/{self._template['template']}.yaml",
             "w",
         ) as file:
             self._yaml_dump(file)

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -471,7 +471,9 @@ class ZabbixCI:
         templates = self._zabbix.get_templates([Settings.ROOT_TEMPLATE_GROUP])
 
         self.logger.info(f"Found {len(templates)} templates in Zabbix")
-        self.logger.debug(f"Found Zabbix templates: {[t['name'] for t in templates]}")
+        self.logger.debug(
+            f"Found Zabbix templates: {[t['template'] for t in templates]}"
+        )
 
         await self.zabbix_export(templates)
         return templates

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -469,9 +469,7 @@ class ZabbixCI:
         templates = self._zabbix.get_templates([Settings.ROOT_TEMPLATE_GROUP])
 
         self.logger.info(f"Found {len(templates)} templates in Zabbix")
-        self.logger.debug(
-            f"Found Zabbix templates: {[t['template'] for t in templates]}"
-        )
+        self.logger.debug(f"Found Zabbix templates: {[t['host'] for t in templates]}")
 
         await self.zabbix_export(templates)
         return templates

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -196,8 +196,6 @@ class ZabbixCI:
             change_amount = len(changes)
 
             for file, status in changes.items():
-                self.logger.info(f"Detected change in {file}")
-
                 if status == FileStatus.WT_DELETED:
                     self.logger.info(f"Detected deletion of {file}")
                     continue


### PR DESCRIPTION
This PR changes the path calculation to use the Zabbix `Template name` field instead of the `Visible name`.

* Path calculation now uses `template.template` key from a Zabbix export.
* Logging of changes now uses `template.host` key from a Zabbix `template.get` request.
* Minor improvements in logging

Closes: #66 