### PR TITLE
🐛 Added missing dashboard rule

### DIFF
--- a/zabbixci/utils/zabbix/zabbix.py
+++ b/zabbixci/utils/zabbix/zabbix.py
@@ -97,6 +97,11 @@ class Zabbix:
                         "updateExisting": True,
                         "deleteMissing": True,
                     },
+                    "templateDashboards": {
+                        "createMissing": True,
+                        "updateExisting": True,
+                        "deleteMissing": True,
+                    },
                     "triggers": {
                         "createMissing": True,
                         "updateExisting": True,


### PR DESCRIPTION
This PR adds the create, update and delete rules for `templateDashboards` fixing missing dashboard items after templates were imported into a fresh Zabbix instance.