### PR TITLE
🐛 Fixed filter matching technical template name

### DIFF
--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -219,7 +219,7 @@ class ZabbixCI:
                         )
                         self._zabbix.set_template(
                             next(
-                                filter(lambda t: t["name"] == template.name, templates)
+                                filter(lambda t: t["host"] == template.name, templates)
                             )["templateid"],
                             template.updated_items,
                         )


### PR DESCRIPTION
This pull request includes a small but important change to the `zabbixci/zabbixci.py` file. The change modifies the filter criteria in the `push` method to use the `host` attribute instead of the `name` attribute when setting the template.

Fixes: #87 