### PR TITLE
🔖 Release v0.1.1

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,7 +2,7 @@ name: Upload Python Package to PyPI when a Release is Created
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   pypi-publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 dynamic = ["version"]
 keywords = ["zabbix", "git", "source control", "templates"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: GNU Affero General Public License v3",


### PR DESCRIPTION
This PR prepares us for the first official release of ZabbixCI

* Fixed Github actions for deployment of builds.
* Changed project status to Beta from Alpha.