### PR TITLE
✨ Dynamically generate icons in different sizes

### DIFF
--- a/zabbixci/cli.py
+++ b/zabbixci/cli.py
@@ -5,6 +5,7 @@ import logging.config
 from sys import version_info
 
 from zabbixci._version import __version__
+from zabbixci.logging import CustomFormatter
 from zabbixci.settings import Settings
 from zabbixci.utils.cache.cache import Cache
 from zabbixci.zabbixci import ZabbixCI
@@ -204,9 +205,13 @@ def parse_cli():
         else logging.INFO if args.verbose else logging.WARN
     )
 
+    ch = logging.StreamHandler()
+
+    ch.setFormatter(CustomFormatter())
+
     logging.basicConfig(
-        format="%(asctime)s [%(name)s]  [%(levelname)s]: %(message)s",
         level=global_level,
+        handlers=[ch],
     )
 
     zabbixci_logger = logging.getLogger("zabbixci")

--- a/zabbixci/cli.py
+++ b/zabbixci/cli.py
@@ -183,6 +183,12 @@ def read_args():
         "--ca-bundle",
         help="Path to CA bundle for SSL verification",
     )
+    parser.add_argument(
+        "--imagemagick-enabled",
+        help="Enable ImageMagick for image conversion",
+        action="store_true",
+        default=None,
+    )
 
     return parser.parse_args()
 

--- a/zabbixci/logging.py
+++ b/zabbixci/logging.py
@@ -1,0 +1,24 @@
+import logging
+
+
+class CustomFormatter(logging.Formatter):
+
+    grey = "\x1b[38;20m"
+    yellow = "\x1b[33;20m"
+    red = "\x1b[31;20m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
+    format = "%(asctime)s [%(name)s]  [%(levelname)s]: %(message)s"
+
+    FORMATS = {
+        logging.DEBUG: grey + format + reset,
+        logging.INFO: grey + format + reset,
+        logging.WARNING: yellow + format + reset,
+        logging.ERROR: red + format + reset,
+        logging.CRITICAL: bold_red + format + reset,
+    }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)

--- a/zabbixci/settings.py
+++ b/zabbixci/settings.py
@@ -38,6 +38,7 @@ class Settings:
     SYNC_TEMPLATES = True
     IMAGE_WHITELIST = ""
     IMAGE_BLACKLIST = ""
+    IMAGE_SIZES = ""
 
     @classmethod
     def get_template_whitelist(cls):
@@ -54,6 +55,11 @@ class Settings:
     @classmethod
     def get_image_blacklist(cls):
         return cls.IMAGE_BLACKLIST.split(",") if cls.IMAGE_BLACKLIST else []
+
+    @classmethod
+    def get_image_sizes(cls):
+        size_strings = cls.IMAGE_SIZES.split(",") if cls.IMAGE_SIZES else []
+        return [tuple(map(int, size.split("x"))) for size in size_strings]
 
     @classmethod
     def from_env(cls):

--- a/zabbixci/settings.py
+++ b/zabbixci/settings.py
@@ -38,7 +38,8 @@ class Settings:
     SYNC_TEMPLATES = True
     IMAGE_WHITELIST = ""
     IMAGE_BLACKLIST = ""
-    IMAGE_SIZES = ""
+    IMAGE_SIZES = "24x24,48x48,64x64,128x128"
+    IMAGEMAGICK_ENABLED = False
 
     @classmethod
     def get_template_whitelist(cls):

--- a/zabbixci/utils/handers/__init__.py
+++ b/zabbixci/utils/handers/__init__.py
@@ -1,3 +1,5 @@
+from .image import ImageHandler
+from .imagemagick import ImagemagickHandler
 from .template import TemplateHandler
 
-__all__ = ["TemplateHandler"]
+__all__ = ["TemplateHandler", "ImageHandler", "ImagemagickHandler"]

--- a/zabbixci/utils/handers/image.py
+++ b/zabbixci/utils/handers/image.py
@@ -52,7 +52,9 @@ class ImageHandler:
             return False
 
         # Check if file is within the desired path
-        if not changed_file.startswith(Settings.IMAGE_PREFIX_PATH):
+        if not Cache.is_within(
+            changed_file, f"{Settings.CACHE_PATH}/{Settings.IMAGE_PREFIX_PATH}"
+        ):
             logger.debug(f"Skipping .png file {changed_file} outside of prefix path")
             return False
 

--- a/zabbixci/utils/handers/imagemagick.py
+++ b/zabbixci/utils/handers/imagemagick.py
@@ -1,0 +1,68 @@
+import logging
+
+from zabbixci.settings import Settings
+from zabbixci.utils.cache.cache import Cache
+
+logger = logging.getLogger(__name__)
+
+
+class Image:
+    """
+    Dummy wand image class
+    """
+
+    pass
+
+
+class ImagemagickHandler:
+    """
+    Wand / ImageMagick wrapper for ZabbixCI, coverts images (icons) to different sizes and formats.
+    """
+
+    @classmethod
+    def _convert(cls, image: Image, size: tuple[int, int], format: str) -> Image:
+        """
+        Convert an image to a different size and format
+
+        :param image: Image to convert
+        :param size: Size to convert to
+        :param format: Format to convert to
+        :return: Converted image
+        """
+        image.resize(size[0], size[1])
+        image.format = format
+
+        return image
+
+    @classmethod
+    def _get_sizes(cls):
+        """
+        Get the sizes to convert images to
+        """
+        return Settings.get_image_sizes()
+
+    @classmethod
+    def create_sized(cls, image_path: str, destination: str, base_name: str):
+        """
+        Create sized images based on the sizes in the settings
+
+        :param image_path: Path to the image
+        """
+        from wand.image import Image
+
+        files: list[str] = []
+        with Cache.open(image_path, "rb") as file:
+            image = Image(file=file)
+
+            for size in cls._get_sizes():
+                avg_size = int((size[0] + size[1]) / 2)
+                file_name = f"{base_name}_({avg_size}).png"
+
+                converted_image = cls._convert(image.clone(), size, "png")
+                with Cache.open(f"{destination}/{file_name}", "wb") as file:
+                    converted_image.save(file=file)
+
+                logger.info(f"Created {file_name}")
+                files.append(f"{destination}/{file_name}")
+
+        return files

--- a/zabbixci/utils/handers/template.py
+++ b/zabbixci/utils/handers/template.py
@@ -5,6 +5,7 @@ from io import StringIO
 from ruamel.yaml import YAML
 
 from zabbixci.settings import Settings
+from zabbixci.utils.cache.cache import Cache
 from zabbixci.utils.services.template import Template
 from zabbixci.utils.zabbix.zabbix import Zabbix
 
@@ -93,7 +94,9 @@ class TemplateHandler:
             return False
 
         # Check if file is within the desired path
-        if not changed_file.startswith(Settings.TEMPLATE_PREFIX_PATH):
+        if not Cache.is_within(
+            changed_file, f"{Settings.CACHE_PATH}/{Settings.TEMPLATE_PREFIX_PATH}"
+        ):
             logger.debug(f"Skipping .yaml file {changed_file} outside of prefix path")
             return False
 

--- a/zabbixci/utils/services/image.py
+++ b/zabbixci/utils/services/image.py
@@ -65,10 +65,10 @@ class Image:
 
     @classmethod
     def open(cls, path: str):
-        with Cache.open(f"{Settings.CACHE_PATH}/{path}", "rb") as file:
+        with Cache.open(path, "rb") as file:
             # TODO: Validation of path ending with /
             matches = regex.match(
-                f"{Settings.IMAGE_PREFIX_PATH}/(icons|backgrounds)/(.*).png", path
+                f".*/{Settings.IMAGE_PREFIX_PATH}/(icons|backgrounds)/(.*).png", path
             )
 
             if not matches:

--- a/zabbixci/utils/services/template.py
+++ b/zabbixci/utils/services/template.py
@@ -215,7 +215,7 @@ class Template:
         """
         Open a template from the cache
         """
-        with Cache.open(f"{Settings.CACHE_PATH}/{path}", "r") as file:
+        with Cache.open(path, "r") as file:
             return Template(yaml.load(file)["zabbix_export"])
 
     @staticmethod

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -126,7 +126,9 @@ class ZabbixCI:
 
             change_amount = len(changes)
 
-            for file, status in changes.items():
+            for relative_path, status in changes.items():
+                file = f"{Settings.CACHE_PATH}/{relative_path}"
+
                 if status == FileStatus.WT_DELETED:
                     self.logger.info(f"Detected deletion of {file}")
                     continue
@@ -227,12 +229,14 @@ class ZabbixCI:
         # Get the changed files, we compare the untracked changes with the desired.
         # When we have a new untracked file, that means it was deleted in the desired state.
         changed_files: list[str] = [
-            path
+            f"{Settings.CACHE_PATH}/{path}"
             for path, flags in status.items()
             if flags in [FileStatus.WT_DELETED, FileStatus.WT_MODIFIED]
         ]
         deleted_files: list[str] = [
-            path for path, flags in status.items() if flags == FileStatus.WT_NEW
+            f"{Settings.CACHE_PATH}/{path}"
+            for path, flags in status.items()
+            if flags == FileStatus.WT_NEW
         ]
 
         self.logger.debug(f"Following files have changed on Git: {changed_files}")

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -250,8 +250,16 @@ class ZabbixCI:
             deleted_files, imported_template_ids, template_objects
         )
 
+        created_images = []
+        if Settings.IMAGEMAGICK_ENABLED:
+            created_images = image_handler.import_dynamic_images()
+
+            self.logger.warning(
+                "Dynamic image creation enabled, rendered images are always imported into Zabbix"
+            )
+
         imported_images = image_handler.import_file_changes(
-            changed_files, image_objects
+            [*changed_files, *created_images], image_objects
         )
         deleted_image_names = image_handler.delete_file_changes(
             deleted_files, imported_images, image_objects


### PR DESCRIPTION
This PR adds the ability to dynamically generate different icon sizes for Zabbix using imagemagick. 

* Adds `imagemagick` handler
* Adds `imagemagick-enabled` flag / config option (default False)
* Made changes to path support in `Template` and `Image` open methods, paths are now full paths including cache directory.
* Added logic to `pull` method implementing image generation. Files in the `{IMG_PREFIX}/dynamic` are automatically converted and saved in `{IMG_PREFIX}/icons/{ORIGINAL_NAME}_({AVG_SIZE_XY}).png`
* Colored log output has been enabled making warnings more visible