### PR TITLE
🐛 Changed vendor match to before 'groups'

### DIFF
--- a/tests/testing.py
+++ b/tests/testing.py
@@ -24,6 +24,7 @@ class TestPushFunctions(unittest.IsolatedAsyncioTestCase):
         Settings.ZABBIX_URL = DEV_ZABBIX_URL
         Settings.ZABBIX_TOKEN = DEV_ZABBIX_TOKEN
         Settings.REMOTE = DEV_GIT_REMOTE
+        Settings.SET_VERSION = True
         Settings.TEMPLATE_WHITELIST = "Linux by Zabbix agent,Linux by Zabbix 00000,Windows by Zabbix agent,Acronis Cyber Protect Cloud by HTTP,Kubernetes API server by HTTP,Kubernetes cluster state by HTTP"
 
         self.zci = ZabbixCI()

--- a/zabbixci/utils/template/template.py
+++ b/zabbixci/utils/template/template.py
@@ -145,13 +145,13 @@ class Template:
     def _insert_vendor_dict(self):
         """
         Insert vendor dict into export.
-        Vendor needs to be positioned after description
+        Vendor needs to be positioned before groups
         to match the Zabbix export format
         """
-        description_index = list(self._template.keys()).index("description")
+        groups_index = list(self._template.keys()).index("groups")
 
         items = list(self._template.items())
-        items.insert(description_index + 1, ("vendor", {}))
+        items.insert(groups_index, ("vendor", {}))
         self._export["templates"][0] = dict(items)
 
     def set_vendor(self, vendor: str):


### PR DESCRIPTION
This PR changed the vendor position logic to match the `groups` key instead of the `description` key. Fixing #92 caused by missing description in a template. Where the `groups` field should always be defined because of enforcement within Zabbix.