### PR TITLE
🐛 Removed Git dependency on `zabbixci version` call

### DIFF
--- a/tests/testing.py
+++ b/tests/testing.py
@@ -40,6 +40,7 @@ class TestPushFunctions(unittest.IsolatedAsyncioTestCase):
         await self.zci.push()
 
     async def asyncSetUp(self):
+        self.zci.create_git()
         await self.zci.create_zabbix()
 
         await self.restoreState()

--- a/zabbixci/cli.py
+++ b/zabbixci/cli.py
@@ -233,10 +233,12 @@ async def run_zabbixci(action: str):
             )
 
         elif action == "push":
+            zabbixci.create_git()
             await zabbixci.create_zabbix()
             await zabbixci.push()
 
         elif action == "pull":
+            zabbixci.create_git()
             await zabbixci.create_zabbix()
             await zabbixci.pull()
 

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -38,7 +38,6 @@ class ZabbixCI:
             self.logger = logger
 
         self.create_git_callback()
-        self.create_git()
 
     def validate_ssl_cert(self, _cert: None, valid: bool, hostname: bytes):
         """


### PR DESCRIPTION
ZabbixCI constructor no longer calls `create_git()` making it possible to skip git repo creation when subsequent methods don't require a valid git repo cache.

Fixes #95 