### PR TITLE
🐛 Fixed dry-run argument and import logging

### DIFF
--- a/test/test_templates_blacklist.py
+++ b/test/test_templates_blacklist.py
@@ -1,14 +1,9 @@
-import logging
-import os
 import unittest
 from os import getenv
 
 from base_templates import BaseTemplates
 
-from zabbixci import ZabbixCI
 from zabbixci.settings import Settings
-from zabbixci.utils.cache.cache import Cache
-from zabbixci.utils.cache.cleanup import Cleanup
 
 DEV_ZABBIX_URL = getenv("ZABBIX_URL")
 DEV_ZABBIX_TOKEN = getenv("ZABBIX_TOKEN")
@@ -17,25 +12,8 @@ DEV_GIT_REMOTE = getenv("REMOTE")
 
 class TestTemplatesBlacklist(BaseTemplates, unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        Settings.CACHE_PATH = "/tmp/zabbixci"
-        self.cache = Cache(Settings.CACHE_PATH)
-
-        if os.path.exists(Settings.CACHE_PATH):
-            Cleanup.cleanup_cache(full=True)
-
-        logging.basicConfig(
-            level=logging.ERROR,
-            format="%(asctime)s - %(name)s - %(message)s",
-        )
-
-        Settings.ZABBIX_URL = DEV_ZABBIX_URL
-        Settings.ZABBIX_TOKEN = DEV_ZABBIX_TOKEN
-        Settings.REMOTE = DEV_GIT_REMOTE
-        Settings.SET_VERSION = True
-        Settings.REGEX_MATCHING = False
+        super().setUp()
         Settings.TEMPLATE_BLACKLIST = "Not existing template,Not existing template 2"
-
-        self.zci = ZabbixCI()
 
     # Test template deletion with whitelist checks
     async def test_template_delete(self):

--- a/test/test_templates_blacklist_regex.py
+++ b/test/test_templates_blacklist_regex.py
@@ -1,14 +1,9 @@
-import logging
-import os
 import unittest
 from os import getenv
 
 from base_templates import BaseTemplates
 
-from zabbixci import ZabbixCI
 from zabbixci.settings import Settings
-from zabbixci.utils.cache.cache import Cache
-from zabbixci.utils.cache.cleanup import Cleanup
 
 DEV_ZABBIX_URL = getenv("ZABBIX_URL")
 DEV_ZABBIX_TOKEN = getenv("ZABBIX_TOKEN")
@@ -17,25 +12,9 @@ DEV_GIT_REMOTE = getenv("REMOTE")
 
 class TestTemplatesBlacklistRegex(BaseTemplates, unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        Settings.CACHE_PATH = "/tmp/zabbixci"
-        self.cache = Cache(Settings.CACHE_PATH)
-
-        if os.path.exists(Settings.CACHE_PATH):
-            Cleanup.cleanup_cache(full=True)
-
-        logging.basicConfig(
-            level=logging.ERROR,
-            format="%(asctime)s - %(name)s - %(message)s",
-        )
-
-        Settings.ZABBIX_URL = DEV_ZABBIX_URL
-        Settings.ZABBIX_TOKEN = DEV_ZABBIX_TOKEN
-        Settings.REMOTE = DEV_GIT_REMOTE
-        Settings.SET_VERSION = True
+        super().setUp()
         Settings.REGEX_MATCHING = True
         Settings.TEMPLATE_BLACKLIST = "Non .*"
-
-        self.zci = ZabbixCI()
 
     # Test template deletion with whitelist checks
     async def test_template_delete(self):

--- a/test/test_templates_whitelist.py
+++ b/test/test_templates_whitelist.py
@@ -1,14 +1,9 @@
-import logging
-import os
 import unittest
 from os import getenv
 
 from base_templates import BaseTemplates
 
-from zabbixci import ZabbixCI
 from zabbixci.settings import Settings
-from zabbixci.utils.cache.cache import Cache
-from zabbixci.utils.cache.cleanup import Cleanup
 
 DEV_ZABBIX_URL = getenv("ZABBIX_URL")
 DEV_ZABBIX_TOKEN = getenv("ZABBIX_TOKEN")
@@ -17,25 +12,8 @@ DEV_GIT_REMOTE = getenv("REMOTE")
 
 class TestTemplatesWhitelist(BaseTemplates, unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        Settings.CACHE_PATH = "/tmp/zabbixci"
-        self.cache = Cache(Settings.CACHE_PATH)
-
-        if os.path.exists(Settings.CACHE_PATH):
-            Cleanup.cleanup_cache(full=True)
-
-        logging.basicConfig(
-            level=logging.ERROR,
-            format="%(asctime)s - %(name)s - %(message)s",
-        )
-
-        Settings.ZABBIX_URL = DEV_ZABBIX_URL
-        Settings.ZABBIX_TOKEN = DEV_ZABBIX_TOKEN
-        Settings.REMOTE = DEV_GIT_REMOTE
-        Settings.SET_VERSION = True
-        Settings.REGEX_MATCHING = False
+        super().setUp()
         Settings.TEMPLATE_WHITELIST = "Linux by Zabbix agent,Linux by Zabbix 00000,Windows by Zabbix agent,Acronis Cyber Protect Cloud by HTTP,Kubernetes API server by HTTP,Kubernetes cluster state by HTTP"
-
-        self.zci = ZabbixCI()
 
     # Test template deletion with whitelist checks
     async def test_template_delete(self):

--- a/test/test_templates_whitelist_regex.py
+++ b/test/test_templates_whitelist_regex.py
@@ -1,14 +1,9 @@
-import logging
-import os
 import unittest
 from os import getenv
 
 from base_templates import BaseTemplates
 
-from zabbixci import ZabbixCI
 from zabbixci.settings import Settings
-from zabbixci.utils.cache.cache import Cache
-from zabbixci.utils.cache.cleanup import Cleanup
 
 DEV_ZABBIX_URL = getenv("ZABBIX_URL")
 DEV_ZABBIX_TOKEN = getenv("ZABBIX_TOKEN")
@@ -17,27 +12,9 @@ DEV_GIT_REMOTE = getenv("REMOTE")
 
 class TestTemplatesWhitelistRegex(BaseTemplates, unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        Settings.CACHE_PATH = "/tmp/zabbixci"
-        self.cache = Cache(Settings.CACHE_PATH)
-
-        if os.path.exists(Settings.CACHE_PATH):
-            Cleanup.cleanup_cache(full=True)
-
-        logging.basicConfig(
-            level=logging.ERROR,
-            format="%(asctime)s - %(name)s - %(message)s",
-        )
-
-        Settings.ZABBIX_URL = DEV_ZABBIX_URL
-        Settings.ZABBIX_TOKEN = DEV_ZABBIX_TOKEN
-        Settings.REMOTE = DEV_GIT_REMOTE
-        Settings.SET_VERSION = True
+        super().setUp()
         Settings.REGEX_MATCHING = True
-        # Settings.TEMPLATE_WHITELIST = "Linux by Zabbix agent,Linux by Zabbix 00000,Windows by Zabbix agent,Acronis Cyber Protect Cloud by HTTP,Kubernetes API server by HTTP,Kubernetes cluster state by HTTP"
-
         Settings.TEMPLATE_WHITELIST = "(Linux|Windows|Acronis|Kubernetes).*"
-
-        self.zci = ZabbixCI()
 
     # Test template deletion with whitelist checks
     async def test_template_delete(self):

--- a/zabbixci/cli.py
+++ b/zabbixci/cli.py
@@ -145,10 +145,11 @@ def read_args():
     )
     zabbixci_group.add_argument(
         "--dry-run",
-        nargs="?",
-        type=str2bool,
-        default=None,
         help="Enable or disable dry run.",
+        const=True,
+        default=None,
+        type=str2bool,
+        nargs="?",
         explicit=True,
     )
     zabbixci_group.add_argument(
@@ -307,6 +308,7 @@ def read_args():
     zabbixci_advanced_group.add_argument(
         "--ignore-template-version",
         help="Ignore template versions on import, useful for initial import",
+        const=True,
         default=None,
         type=str2bool,
         nargs="?",

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -266,9 +266,7 @@ class ZabbixCI:
         # Inform user about the changes
         if Settings.DRY_RUN:
             self.logger.info(
-                "Dry run enabled, no changes will be made to Zabbix.",
-                f"Would have imported {len(imported_template_ids)} templates and deleted {len(deleted_template_names)} templates.",
-                f"Would have imported {len(imported_images)} images and deleted {len(deleted_image_names)} images.",
+                f"Dry run enabled, no changes will be made to Zabbix. Would have imported {len(imported_template_ids)} templates and deleted {len(deleted_template_names)} templates. Would have imported {len(imported_images)} images and deleted {len(deleted_image_names)} images.",
             )
         else:
             if (
@@ -280,9 +278,7 @@ class ZabbixCI:
                 self.logger.info("No changes detected, Zabbix is up to date")
             else:
                 self.logger.info(
-                    "Zabbix state has been synchronized.",
-                    f"Imported {len(imported_template_ids)} templates and deleted {len(deleted_template_names)} templates.",
-                    f"Imported {len(imported_images)} images and deleted {len(deleted_image_names)} images.",
+                    "Zabbix state has been synchronized. Imported {len(imported_template_ids)} templates and deleted {len(deleted_template_names)} templates. Imported {len(imported_images)} images and deleted {len(deleted_image_names)} images.",
                 )
 
         # clean local changes

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -278,7 +278,7 @@ class ZabbixCI:
                 self.logger.info("No changes detected, Zabbix is up to date")
             else:
                 self.logger.info(
-                    "Zabbix state has been synchronized. Imported {len(imported_template_ids)} templates and deleted {len(deleted_template_names)} templates. Imported {len(imported_images)} images and deleted {len(deleted_image_names)} images.",
+                    f"Zabbix state has been synchronized. Imported {len(imported_template_ids)} templates and deleted {len(deleted_template_names)} templates. Imported {len(imported_images)} images and deleted {len(deleted_image_names)} images.",
                 )
 
         # clean local changes


### PR DESCRIPTION
This PR fixes the `--dry-run` argument which was not read properly in `v0.2.0`. It also fixes the logging of the import summary at the end of a run.

Also includes some cleanup of the tests.