### PR TITLE
✨ Zabbix 6.0 support

### DIFF
--- a/zabbixci/assets/template.py
+++ b/zabbixci/assets/template.py
@@ -141,7 +141,12 @@ class Template(Asset):
         """
         Dump Zabbix importable template to stream
         """
-        yaml.dump({"zabbix_export": self._export}, stream)
+        prepared_export = self._export.copy()
+
+        if "date" in prepared_export:
+            del prepared_export["date"]
+
+        yaml.dump({"zabbix_export": prepared_export}, stream)
 
     def _insert_vendor_dict(self):
         """

--- a/zabbixci/zabbix/zabbix.py
+++ b/zabbixci/zabbix/zabbix.py
@@ -13,6 +13,10 @@ class Zabbix:
     zapi: AsyncZabbixAPI
     _client_session = None
 
+    @property
+    def api_version(self):
+        return self.zapi.version
+
     def __init__(self, *args, **kwargs):
         if "ssl_context" in kwargs:
             if kwargs["ssl_context"]:

--- a/zabbixci/zabbix/zabbix.py
+++ b/zabbixci/zabbix/zabbix.py
@@ -84,7 +84,7 @@ class Zabbix:
                                 "updateExisting": True,
                             }
                         }
-                        if self.api_version > 7.0
+                        if self.api_version >= 7.0
                         else {
                             "groups": {
                                 "createMissing": True,

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -57,7 +57,7 @@ class ZabbixCI:
             self.logger.debug("Using token for Zabbix authentication")
             await self._zabbix.zapi.login(token=self._settings.ZABBIX_TOKEN)
 
-        if self._zabbix.zapi.version < 7.0:
+        if self._zabbix.zapi.version < 6.0:
             self.logger.error(
                 f"Zabbix server version {self._zabbix.zapi.version} is not supported (7.0+ required)"
             )

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -155,12 +155,16 @@ class ZabbixCI:
 
                 template = Template.open(file)
 
-                if Settings.VENDOR and not template.vendor:
+                if (
+                    Settings.VENDOR
+                    and not template.vendor
+                    and self._zabbix.api_version >= 7.0
+                ):
                     set_vendor = Settings.VENDOR
                     template.set_vendor(set_vendor)
                     self.logger.debug(f"Setting vendor to: {set_vendor}")
 
-                if Settings.SET_VERSION:
+                if Settings.SET_VERSION and self._zabbix.api_version >= 7.0:
                     new_version = datetime.now(timezone.utc).strftime("%Y.%m.%d %H:%M")
                     template.set_version(new_version)
                     self.logger.debug(f"Setting version to: {new_version}")


### PR DESCRIPTION
This PR adds support for Zabbix 6.0 communication, making a couple of changes to the template handler to use different mappings when the Zabbix 6.0 api is used.

* Template group mapping has been adjusted for 6.0
* Template exports now remove the date key from the export dict
* Version requirement has been added to set-version and set-vendor functions
* Minimum Zabbix version has been lowered from 7.0 to 6.0

Closes #115 