### PR TITLE
🐛 Fixed mapping of boolean environment values

### DIFF
--- a/zabbixci/settings.py
+++ b/zabbixci/settings.py
@@ -86,9 +86,12 @@ class Settings:
 
     @classmethod
     def from_env(cls):
-        for key in cls.__dict__.keys():
+        for key, value in cls.__dict__.items():
             if key in os.environ:
-                setattr(cls, key, os.environ[key])
+                if isinstance(value, bool):
+                    setattr(cls, key, os.environ[key].lower() == "true")
+                else:
+                    setattr(cls, key, os.environ[key])
 
     @classmethod
     def read_config(cls, path):


### PR DESCRIPTION
Boolean environment values can now have a value of `"false"` and be considered `False` instead of `True`