### PR TITLE
🐛 Fixed template import count on dry-run

### DIFF
--- a/zabbixci/handlers/synchronization/template_synchronization.py
+++ b/zabbixci/handlers/synchronization/template_synchronization.py
@@ -172,6 +172,11 @@ class TemplateHandler(TemplateValidationHandler):
                     )
                     logger.debug("Error details: %s", e)
                     retry_templates.append(template)
+        else:
+            # Dry-run is enabled, don't import but increment success count
+            success_templates.extend(
+                [t.template_ids for t in templates if t.template_ids]
+            )
 
         if retry_templates:
             for template in retry_templates:


### PR DESCRIPTION
Fixed the template import count when the dry-run option is enabled. In 0.3.3 this would result in an empty `success_templates` list, which is used in the summary to display the imported template count. This change introduces a fallback when the dry-run option is enabled to fill the `success_templates` list with all templates that would have been imported.

Previous behavior
```
2025-04-26 10:38:34  [INFO]: Detected change in template: Kubernetes cluster state by HTTP
2025-04-26 10:38:34  [INFO]: Dry run enabled, no changes will be made to Zabbix
2025-04-26 10:38:34  [INFO]: Would have imported 0 templates, deleted 0 templates
```

New behavior
```
2025-04-26 10:38:47  [INFO]: Detected change in template: Kubernetes cluster state by HTTP
2025-04-26 10:38:47  [INFO]: Dry run enabled, no changes will be made to Zabbix
2025-04-26 10:38:47  [INFO]: Would have imported 1 templates, deleted 0 templates
```

Fixes #136 