### PR TITLE
✨ Add skip_version_check option for Zabbix API

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -290,3 +290,9 @@ ca_bundle: ""
 # Mandatory: no
 # Default: false
 regex_matching: false
+
+### Option: skip_version_check
+# Skip version check for Zabbix.
+# Mandatory: no
+# Default: false
+skip_version_check: false

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -48,11 +48,12 @@ You should now be able to run ZabbixCI:
 
 ```console
 user@localhost:~$ zabbixci
-usage: zabbixci [-h] [-c CONFIG] [--root-template-group ROOT_TEMPLATE_GROUP] [--template-prefix-path TEMPLATE_PREFIX_PATH] [--image-prefix-path IMAGE_PREFIX_PATH] [--icon-map-prefix-path ICON_MAP_PREFIX_PATH] [--template-whitelist TEMPLATE_WHITELIST] [--template-blacklist TEMPLATE_BLACKLIST] [--image-whitelist IMAGE_WHITELIST]
-                [--image-blacklist IMAGE_BLACKLIST] [--icon-map-whitelist ICON_MAP_WHITELIST] [--icon-map-blacklist ICON_MAP_BLACKLIST] [--cache-path CACHE_PATH] [--dry-run [DRY_RUN]] [--vendor VENDOR] [--set-version [SET_VERSION]] [--sync-templates [SYNC_TEMPLATES]] [--sync-icons [SYNC_ICONS]] [--sync-backgrounds [SYNC_BACKGROUNDS]]
-                [--sync-icon-maps [SYNC_ICON_MAPS]] [--icon-sizes ICON_SIZES] [--background-sizes BACKGROUND_SIZES] [--zabbix-url ZABBIX_URL] [--zabbix-user ZABBIX_USER] [--zabbix-password ZABBIX_PASSWORD] [--zabbix-token ZABBIX_TOKEN] [--remote REMOTE] [--pull-branch PULL_BRANCH] [--push-branch PUSH_BRANCH] [--git-username GIT_USERNAME]
-                [--git-password GIT_PASSWORD] [--git-pubkey GIT_PUBKEY] [--git-privkey GIT_PRIVKEY] [--git-keypassphrase GIT_KEYPASSPHRASE] [--git-author-name GIT_AUTHOR_NAME] [--git-author-email GIT_AUTHOR_EMAIL] [-m GIT_COMMIT_MESSAGE] [-v [VERBOSE]] [-vv [DEBUG]] [-vvv [DEBUG_ALL]] [--batch-size BATCH_SIZE]
-                [--ignore-template-version [IGNORE_TEMPLATE_VERSION]] [--insecure-ssl-verify [INSECURE_SSL_VERIFY]] [--ca-bundle CA_BUNDLE] [--regex-matching [REGEX_MATCHING]]
+usage: zabbixci [-h] [-c CONFIG] [--root-template-group ROOT_TEMPLATE_GROUP] [--template-prefix-path TEMPLATE_PREFIX_PATH] [--image-prefix-path IMAGE_PREFIX_PATH] [--icon-map-prefix-path ICON_MAP_PREFIX_PATH] [--template-whitelist TEMPLATE_WHITELIST] [--template-blacklist TEMPLATE_BLACKLIST]
+                [--image-whitelist IMAGE_WHITELIST] [--image-blacklist IMAGE_BLACKLIST] [--icon-map-whitelist ICON_MAP_WHITELIST] [--icon-map-blacklist ICON_MAP_BLACKLIST] [--cache-path CACHE_PATH] [--dry-run [DRY_RUN]] [--vendor VENDOR] [--set-version [SET_VERSION]]
+                [--sync-templates [SYNC_TEMPLATES]] [--sync-icons [SYNC_ICONS]] [--sync-backgrounds [SYNC_BACKGROUNDS]] [--sync-icon-maps [SYNC_ICON_MAPS]] [--icon-sizes ICON_SIZES] [--background-sizes BACKGROUND_SIZES] [--zabbix-url ZABBIX_URL] [--zabbix-user ZABBIX_USER]
+                [--zabbix-password ZABBIX_PASSWORD] [--zabbix-token ZABBIX_TOKEN] [--remote REMOTE] [--pull-branch PULL_BRANCH] [--push-branch PUSH_BRANCH] [--git-username GIT_USERNAME] [--git-password GIT_PASSWORD] [--git-pubkey GIT_PUBKEY] [--git-privkey GIT_PRIVKEY]
+                [--git-keypassphrase GIT_KEYPASSPHRASE] [--git-author-name GIT_AUTHOR_NAME] [--git-author-email GIT_AUTHOR_EMAIL] [-m GIT_COMMIT_MESSAGE] [-v [VERBOSE]] [-vv [DEBUG]] [-vvv [DEBUG_ALL]] [--batch-size BATCH_SIZE] [--ignore-template-version [IGNORE_TEMPLATE_VERSION]]
+                [--skip-version-check [SKIP_VERSION_CHECK]] [--insecure-ssl-verify [INSECURE_SSL_VERIFY]] [--ca-bundle CA_BUNDLE] [--regex-matching [REGEX_MATCHING]]
                 {push,pull,clearcache,version,generate-icons,generate-backgrounds}
 zabbixci: error: the following arguments are required: action
 user@localhost:~$

--- a/test/base_icon_map.py
+++ b/test/base_icon_map.py
@@ -30,6 +30,7 @@ class BaseIconMap:
         Settings.ZABBIX_TOKEN = DEV_ZABBIX_TOKEN
         Settings.REMOTE = DEV_GIT_REMOTE
         Settings.REGEX_MATCHING = False
+        Settings.SKIP_VERSION_CHECK = True
         Settings.SET_VERSION = True
 
         Settings.SYNC_TEMPLATES = False

--- a/test/base_images.py
+++ b/test/base_images.py
@@ -30,6 +30,7 @@ class BaseImages:
         Settings.ZABBIX_TOKEN = DEV_ZABBIX_TOKEN
         Settings.REMOTE = DEV_GIT_REMOTE
         Settings.REGEX_MATCHING = False
+        Settings.SKIP_VERSION_CHECK = True
         Settings.SET_VERSION = True
 
         Settings.SYNC_TEMPLATES = False

--- a/test/base_templates.py
+++ b/test/base_templates.py
@@ -29,6 +29,7 @@ class BaseTemplates:
         Settings.ZABBIX_URL = DEV_ZABBIX_URL
         Settings.ZABBIX_TOKEN = DEV_ZABBIX_TOKEN
         Settings.REMOTE = DEV_GIT_REMOTE
+        Settings.SKIP_VERSION_CHECK = True
         Settings.REGEX_MATCHING = False
         Settings.SET_VERSION = True
 

--- a/zabbixci/cli.py
+++ b/zabbixci/cli.py
@@ -351,6 +351,15 @@ def read_args(args: list[str] | None = None):
         explicit=True,
     )
     zabbixci_advanced_group.add_argument(
+        "--skip-version-check",
+        help="Skip version check for Zabbix API",
+        const=True,
+        default=None,
+        type=str2bool,
+        nargs="?",
+        explicit=True,
+    )
+    zabbixci_advanced_group.add_argument(
         "--insecure-ssl-verify",
         help="Disable SSL verification for Zabbix API and git, only use for testing",
         const=True,

--- a/zabbixci/settings.py
+++ b/zabbixci/settings.py
@@ -50,6 +50,7 @@ class Settings:
     REGEX_MATCHING: bool = False
     ICON_MAP_WHITELIST: str = ""
     ICON_MAP_BLACKLIST: str = ""
+    SKIP_VERSION_CHECK: bool = False
 
     @classmethod
     def get_template_whitelist(cls):

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -46,6 +46,7 @@ class ZabbixCI:
             url=self._settings.ZABBIX_URL,
             validate_certs=not self._settings.INSECURE_SSL_VERIFY,
             ssl_context=self._ssl_context,
+            skip_version_check=self._settings.SKIP_VERSION_CHECK,
         )
 
         if self._settings.ZABBIX_USER and self._settings.ZABBIX_PASSWORD:


### PR DESCRIPTION
zabbix_utils requires a skip_version_check argument on construction of the API instance when a untested Zabbix version is used. ZabbixCI should allow the user to take this risk and skip the version check.

Adds skip_version_check and --skip-version-check config and CLI options to skin the ZabbixAPI version check.

Fixes #141 