### PR TITLE
🐛 Added utf-8 encoding for opening of config file

### DIFF
--- a/zabbixci/settings.py
+++ b/zabbixci/settings.py
@@ -96,7 +96,7 @@ class Settings:
 
     @classmethod
     def read_config(cls, path):
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             data = yaml.load(f)
             for key, value in data.items():
                 setattr(cls, key.upper(), value)


### PR DESCRIPTION
Adds an encoding argument to the opening of the YAML config file, can mitigate unwanted errors when configs are copied between different systems. (like our example config)