### PR TITLE
✨ Added optional overwrite of construction kwargs for Zabbix and Git

### DIFF
--- a/zabbixci/git/git.py
+++ b/zabbixci/git/git.py
@@ -17,7 +17,7 @@ class Git:
     author: Signature
     _git_cb = None
 
-    def __init__(self, path: str, callbacks: RemoteCallbacks):
+    def __init__(self, path: str, callbacks: RemoteCallbacks, **kwargs):
         """
         Initialize the git repository
         """
@@ -31,6 +31,7 @@ class Git:
                 Settings.REMOTE,
                 path,
                 callbacks=self._git_cb,
+                **kwargs,
             )
         else:
             self._repository = Repository(path)

--- a/zabbixci/settings.py
+++ b/zabbixci/settings.py
@@ -50,6 +50,8 @@ class Settings:
     REGEX_MATCHING: bool = False
     ICON_MAP_WHITELIST: str = ""
     ICON_MAP_BLACKLIST: str = ""
+    ZABBIX_KWARGS: dict = {}
+    GIT_KWARGS: dict = {}
 
     @classmethod
     def get_template_whitelist(cls):
@@ -88,6 +90,10 @@ class Settings:
     @classmethod
     def from_env(cls):
         for key, value in cls.__dict__.items():
+            # Dict values can only be set in the yaml config file
+            if isinstance(value, dict):
+                continue
+
             if key in os.environ:
                 if isinstance(value, bool):
                     setattr(cls, key, os.environ[key].lower() == "true")

--- a/zabbixci/zabbixci.py
+++ b/zabbixci/zabbixci.py
@@ -46,6 +46,7 @@ class ZabbixCI:
             url=self._settings.ZABBIX_URL,
             validate_certs=not self._settings.INSECURE_SSL_VERIFY,
             ssl_context=self._ssl_context,
+            **self._settings.ZABBIX_KWARGS,
         )
 
         if self._settings.ZABBIX_USER and self._settings.ZABBIX_PASSWORD:
@@ -70,7 +71,7 @@ class ZabbixCI:
         if git_cb is None:
             git_cb = GitCredentials().create_git_callback()
 
-        self._git = Git(self._settings.CACHE_PATH, git_cb)
+        self._git = Git(self._settings.CACHE_PATH, git_cb, **self._settings.GIT_KWARGS)
 
     async def push(self) -> bool:
         """


### PR DESCRIPTION
Adds special `ZABBIX_KWARGS` and `GIT_KWARGS` options only available by setting these values in the config file. Allows the user to provide advanced options to the ZabbixAPI or pygit2 instances in the form of additional arguments passed as kwargs. This option should be used for debugging or to configure additional options not yet supported by normal ZabbixCI configuration options.

Example:
```yaml
remote: "git@example.nl:zabbixci-remote"
template_prefix_path: ZabbixCI
...
...
zabbix_kwargs:
  timeout: 120
  http_user: "example"
git_kwargs:
  depth: 2
```