### PR TITLE
⬆️ Zabbix-Utils upgrade to 2.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
     "pygit2>=1.17.0",
     "regex>=2024.11.6",
     "ruamel.yaml>=0.18.10",
-    "zabbix_utils>=2.0.2",
-    "Wand>=0.6.13"
+    "zabbix_utils>=2.0.3",
+    "Wand>=0.6.13",
 ]
 license = { file = "LICENSE.txt" }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ ruamel.yaml==0.18.14
 ruamel.yaml.clib==0.2.12
 Wand==0.6.13
 yarl==1.20.1
-zabbix-utils==2.0.2
+zabbix-utils==2.0.3


### PR DESCRIPTION
This PR upgrades the minimum zabbix-utils version to 2.0.3, as this provides proper 7.4 support ([zabbix-utils changelog](https://github.com/zabbix/python-zabbix-utils/releases/tag/v2.0.3))