### PR TITLE
📝 Fixed action badge for pypi build action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![ZabbixCI cog logo](https://raw.githubusercontent.com/retigra/zabbixci/main/logo.png "ZabbixCI logo")
 
 ![PyPI - Version](https://img.shields.io/pypi/v/zabbixci)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/retigra/ZabbixCI/pypi.yml?label=pypi%20build)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/retigra/ZabbixCI/pypi.yaml?label=pypi%20build)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/retigra/ZabbixCI/ghcr.yaml?label=docker%20build)
 
 > [!WARNING]


### PR DESCRIPTION
Pip publish action was renamed in #172, badge needs to reflect this action rename for it to function.