### PR TITLE
🐛 Ssh dependencies missing in docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.opencontainers.image.licenses=AGPL
 LABEL org.opencontainers.image.vendor="Retigra"
 LABEL org.opencontainers.image.authors="info@retigra.nl"
 
-RUN apt-get update && apt-get install -y imagemagick && apt-get clean
+RUN apt-get update && apt-get install -y imagemagick git && apt-get clean
 
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 COPY --from=builder --chown=app:app /app/zabbixci /app/zabbixci


### PR DESCRIPTION
Dependencies for git operations are missing from published docker image. Causing errors on SSH operations when using ZabbixCI