### PR TITLE
🔧 Changed hostgroup threshold to 6.2

### DIFF
--- a/zabbixci/zabbix/zabbix.py
+++ b/zabbixci/zabbix/zabbix.py
@@ -40,7 +40,7 @@ class Zabbix:
             "searchWildcardsEnabled": True,
         }
 
-        if self.api_version < 7.0:
+        if self.api_version < 6.2:
             return self.zapi.send_sync_request("hostgroup.get", params)["result"]
         else:
             return self.zapi.send_sync_request(
@@ -95,7 +95,7 @@ class Zabbix:
                                 "updateExisting": True,
                             },
                         }
-                        if self.api_version >= 7.0
+                        if self.api_version >= 6.2
                         else {
                             "groups": {
                                 "createMissing": True,


### PR DESCRIPTION
Backport of #212 for 0.3

Changes version threshold of template groups to version 6.2 instead of 7.0. While 6.2 and 6.4 aren't supported, this is a minor change improving compatibility in dire situations. 